### PR TITLE
Small fix so manhattan_plot works for GRanges objects.

### DIFF
--- a/R/manhattan.R
+++ b/R/manhattan.R
@@ -254,7 +254,7 @@ setMethod(
       x, signif = signif, pval.colname = pval.colname, chr.order = chr.order,
       signif.col = signif.col, chr.col = chr.col, highlight.colname = highlight.colname,
       highlight.col = highlight.col, preserve.position = preserve.position, thin = thin,
-      thin.n
+      thin.n = thin.n, chromosome = chromosome, ...
     )
 
     # manhattan plot


### PR DESCRIPTION
It's just the call to `manhattan_data_preprocess`, where not all arguments are named and there's no chromosome argument nor an ellipsis argument.